### PR TITLE
[#13] Implement endpoint that will take Query and call the real API

### DIFF
--- a/github-graphql.cabal
+++ b/github-graphql.cabal
@@ -65,8 +65,14 @@ library
   exposed-modules:     GitHub
                          GitHub.GraphQL
                          GitHub.Render
+                         GitHub.Query
 
-  build-depends:       text ^>= 1.2.3
+  build-depends:       aeson ^>= 1.5
+                     , bytestring ^>= 0.10
+                     , http-client ^>= 0.7
+                     , http-client-tls ^>= 0.3
+                     , http-types ^>= 0.12
+                     , text ^>= 1.2.3
 
 test-suite github-graphql-test
   import:              common-options

--- a/src/GitHub/Query.hs
+++ b/src/GitHub/Query.hs
@@ -1,0 +1,91 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+
+{- |
+Copyright: (c) 2020 Kowainik
+SPDX-License-Identifier: MPL-2.0
+Maintainer: Kowainik <xrom.xkov@gmail.com>
+
+Submit HTTPS query to to GitHub GraphQL API.
+-}
+
+-- TODO: better module name
+module GitHub.Query
+    ( GitHubToken (..)
+    , callGitHub
+    ) where
+
+import Control.Exception (throwIO)
+import Data.Aeson (FromJSON (..), eitherDecode, encode, object, withObject, (.:), (.=))
+import Data.ByteString (ByteString)
+import Network.HTTP.Client (RequestBody (RequestBodyLBS), httpLbs, method, parseRequest,
+                            requestBody, requestHeaders, responseBody, responseStatus)
+import Network.HTTP.Client.TLS (newTlsManager)
+import Network.HTTP.Types.Status (statusCode)
+import Type.Reflection (Typeable, typeRep)
+
+import GitHub.GraphQL (Query)
+import GitHub.Render (renderTopQuery)
+
+
+{- | GitHub OAuth token.
+-}
+newtype GitHubToken = GitHubToken
+    { unGitHubToken :: ByteString
+    }
+
+
+{- | Call GitHub API with a token
+-}
+callGitHub
+    :: forall a
+    .  (Typeable a, FromJSON a)
+    => GitHubToken  -- ^ Bearer token
+    -> Query  -- ^ GraphQL query
+    -> IO a
+callGitHub (GitHubToken token) query = do
+    manager <- newTlsManager
+
+    initialRequest <- parseRequest "https://api.github.com/graphql"
+    let queryBody = object ["query" .= renderTopQuery query]
+
+    let request = initialRequest
+            { method = "POST"
+            , requestHeaders =
+                  ("Authorization", "bearer " <> token)
+                : ("User-Agent", "kowainik/github-graphql")
+                : requestHeaders initialRequest
+            , requestBody = RequestBodyLBS $ encode queryBody
+            }
+
+    -- calling the API
+    response <- httpLbs request manager
+
+    case statusCode $ responseStatus response of
+        200 -> case eitherDecode @(Data a) (responseBody response) of
+            Left err ->
+                throwIO $ userError $ "Error decoding JSON response: " <> err
+            Right (Data res) ->
+                pure res
+        code -> throwIO $ userError $ "Non-200 response code: " <> show code
+
+{- | Local wrapper to parse objects inside the @data@ field. GraphQL
+API returns JSON of the following shape.
+
+@
+{
+    "data": { ... actual result ... }
+}
+@
+
+This wrapper handles extra layer of @data@.
+-}
+newtype Data a = Data a
+
+instance (Typeable a, FromJSON a) => FromJSON (Data a) where
+    parseJSON = withObject (typeName @a) $ \o -> do
+        val <- o .: "data"
+        pure $ Data val
+
+-- copy-pasted from @relude@
+typeName :: forall a. Typeable a => String
+typeName = show (typeRep @a)


### PR DESCRIPTION
Resolves #13

Managed to write working code somehow... Just glued multiple pieces together. But any suggestions (especially naming ones) are really appreciated!).

Strictly speaking, dependency on `aeson` is not really necessary, and the API can return `ByteString`. But users of `github-graphql` will need to use `aeson` anyway, so I've decided to depend on it and provide several utilities (like the `Data` newtype).

I checked, that it works and calls the API (with the temporary version that returns `ByteString`):

```haskell
λ: token = GitHubToken "1f777a210889b833815a0175c5c0d886839091f0"
λ: callGitHub token (repositoryToAst exampleQuery)
The status code was: Status {statusCode = 200, statusMessage = "OK"}
"{"data":{"repository":{"issues":{"nodes":[{"title":"Use 'git stash push' and handle optional argument to 'hit stash' to stash individual files","author":{"login":"chshersh"}},{"title":"Add --color-moved to hit diff","author":{"login":"vrom911"}},{"title":"[RFC] Warn about suspicious files","author":{"login":"vrom911"}}]},"pullRequests":{"nodes":[]}}}}"
```

But it also works now with Aeson types! Now users of `github-graphql` only need to write manual `FromJSON` instances for their types:

```haskell
λ: callGitHub token (repositoryToAst exampleQuery) :: IO Value
Object
    ( fromList
        [
            ( "repository"
            , Object
                ( fromList
                    [
                        ( "pullRequests"
                        , Object
                            ( fromList
                                [
                                    ( "nodes"
                                    , Array []
                                    )
                                ]
                            )
                        )
...
```