### PR TITLE
[#10] Implement lens API for setting query args

### DIFF
--- a/github-graphql.cabal
+++ b/github-graphql.cabal
@@ -68,9 +68,10 @@ library
                          GitHub.GraphQL
                          GitHub.Issues
                          GitHub.Lens
+                         GitHub.PullRequests
                          GitHub.Render
                          GitHub.Repository
-                         GitHub.PullRequests
+                         GitHub.RequiredField
                          GitHub.Title
                          GitHub.Query
 

--- a/github-graphql.cabal
+++ b/github-graphql.cabal
@@ -67,6 +67,7 @@ library
                          GitHub.Connection
                          GitHub.GraphQL
                          GitHub.Issues
+                         GitHub.Lens
                          GitHub.Render
                          GitHub.Repository
                          GitHub.PullRequests
@@ -78,7 +79,9 @@ library
                      , http-client ^>= 0.7
                      , http-client-tls ^>= 0.3
                      , http-types ^>= 0.12
+                     , prolens ^>= 0.0
                      , text ^>= 1.2.3
+                     , type-errors-pretty ^>= 0.0.1.1
 
 test-suite github-graphql-test
   import:              common-options

--- a/src/GitHub.hs
+++ b/src/GitHub.hs
@@ -25,17 +25,25 @@ module GitHub
     , module GitHub.Author
     , module GitHub.Title
 
+      -- * General tools to work with API
+      -- ** Using lenses to change fields
+    , module GitHub.Lens
+
       -- * Temp
     , exampleQuery
     , projectName
     ) where
 
+import Data.Function ((&))
 import Data.List.NonEmpty (NonEmpty (..))
+import Prolens (set)
+
 
 import GitHub.Author
 import GitHub.Connection
 import GitHub.GraphQL (State (..))
 import GitHub.Issues
+import GitHub.Lens
 import GitHub.PullRequests
 import GitHub.Repository
 import GitHub.Title
@@ -76,19 +84,27 @@ query {
 -}
 exampleQuery :: Repository
 exampleQuery = repository
-    (RepositoryArgs { repositoryArgsOwner = "kowainik", repositoryArgsName = "hit-on"})
+    ( defRepositoryArgs
+    & set ownerL "kowainik"
+    & set nameL  "hit-on"
+    )
     $ issues
-        (IssuesArgs { issuesArgsLast = 3, issuesArgsStates = one Open })
+        ( defIssuesArgs
+        & set lastL 3
+        & set statesL (one Open)
+        )
         (one $ nodes $
            title :|
            [author $ one login]
         )
     :|
     [ pullRequests
-        (PullRequestsArgs { pullRequestsLast = 3, pullRequestsStates = one Open })
+        ( defPullRequestsArgs
+        & set lastL 3
+        & set statesL (one Open)
+        )
         (one $ nodes $
            title :|
            [author $ one login]
         )
-
     ]

--- a/src/GitHub/Issues.hs
+++ b/src/GitHub/Issues.hs
@@ -27,7 +27,8 @@ import {-# SOURCE #-} GitHub.Author (AuthorField, authorToAst)
 import GitHub.Connection (Connection (..), connectionToAst)
 import GitHub.GraphQL (NodeName (..), ParamName (..), ParamValue (..), QueryNode (..),
                        QueryParam (..), State (..), mkQuery, nameNode)
-import GitHub.Lens (ArgsType (..), HasLimit (..), HasStates (..))
+import GitHub.Lens (LimitL (..), StatesL (..))
+import GitHub.RequiredField (RequiredField (..))
 
 
 {- | The @issues@ connection of the 'Repository' object.
@@ -48,23 +49,23 @@ issuesToAst Issues{..} = QueryNode
 
 {- | Arguments for the 'Issues' connection.
 -}
-data IssuesArgs (args :: [ArgsType]) = IssuesArgs
+data IssuesArgs (fields :: [RequiredField]) = IssuesArgs
     { issuesArgsLast   :: !Int
     , issuesArgsStates :: !(NonEmpty State)
     }
 
-instance HasLimit IssuesArgs where
+instance LimitL IssuesArgs where
     lastL = lens issuesArgsLast (\args new -> args { issuesArgsLast = new })
     {-# INLINE lastL #-}
 
-instance HasStates IssuesArgs where
+instance StatesL IssuesArgs where
     statesL = lens issuesArgsStates (\args new -> args { issuesArgsStates = new })
     {-# INLINE statesL #-}
 
 {- | Default value of 'IssuesArgs'. Use methods of 'HasLimit' and
 'HasStates' to change its fields.
 -}
-defIssuesArgs :: IssuesArgs '[ 'ArgsLimit, 'ArgsStates ]
+defIssuesArgs :: IssuesArgs '[ 'FieldLimit, 'FieldStates ]
 defIssuesArgs = IssuesArgs
     { issuesArgsLast = -1
     , issuesArgsStates = Open :| []

--- a/src/GitHub/Lens.hs
+++ b/src/GitHub/Lens.hs
@@ -1,0 +1,68 @@
+{-# LANGUAGE DataKinds     #-}
+{-# LANGUAGE PolyKinds     #-}
+{-# LANGUAGE TypeFamilies  #-}
+{-# LANGUAGE TypeOperators #-}
+
+{- |
+Copyright: (c) 2021 Kowainik
+SPDX-License-Identifier: MPL-2.0
+Maintainer: Kowainik <xrom.xkov@gmail.com>
+
+Utilities to provide general @lens@-like API for creating GraphQL
+queries.
+-}
+
+module GitHub.Lens
+    ( HasOwnerName (..)
+    , HasLimit (..)
+    , HasStates (..)
+
+      -- * Parameter types
+    , ArgsType (..)
+
+      -- * Internas
+    , Delete
+    ) where
+
+import Data.Kind (Type)
+import Data.List.NonEmpty (NonEmpty)
+import Data.Text (Text)
+import Prolens (Lens)
+
+import GitHub.GraphQL (State)
+
+
+{- | Type of fields for arguments.
+-}
+data ArgsType
+    = ArgsOwner
+    | ArgsName
+    | ArgsLimit
+    | ArgsStates
+
+{- | Typeclass for lenses that can change owner and name
+-}
+class HasOwnerName (r :: [ArgsType] -> Type) where
+    ownerL :: Lens (r args) (r (Delete 'ArgsOwner args)) Text Text
+    nameL  :: Lens (r args) (r (Delete 'ArgsName args)) Text Text
+
+{- | Typeclass for lenses that can change the limit of elements.
+-}
+class HasLimit (r :: [ArgsType] -> Type) where
+    lastL  :: Lens (r args) (r (Delete 'ArgsLimit args)) Int Int
+    -- firstL :: Lens (r args) (r (Delete 'ArgsLimit args)) Int Int
+
+{- | Typeclass for lenses that can change states.
+-}
+class HasStates (r :: [ArgsType] -> Type) where
+    statesL :: Lens (r args) (r (Delete 'ArgsStates args)) (NonEmpty State) (NonEmpty State)
+
+
+-- Internal helpers
+
+{- | Type family to delete element from the type-level list.
+-}
+type family Delete (e :: k) (list :: [k]) :: [k] where
+    Delete _ '[]       = '[]
+    Delete x (x ': xs) = xs
+    Delete x (y ': xs) = y ': Delete x xs

--- a/src/GitHub/Lens.hs
+++ b/src/GitHub/Lens.hs
@@ -8,19 +8,18 @@ Copyright: (c) 2021 Kowainik
 SPDX-License-Identifier: MPL-2.0
 Maintainer: Kowainik <xrom.xkov@gmail.com>
 
-Utilities to provide general @lens@-like API for creating GraphQL
+Typeclasses for providing @lens@-like API for creating GraphQL
 queries.
 -}
 
 module GitHub.Lens
-    ( HasOwnerName (..)
-    , HasLimit (..)
-    , HasStates (..)
+    ( -- * Typeclasses with lenses
+      LimitL (..)
+    , NameL (..)
+    , OwnerL (..)
+    , StatesL (..)
 
-      -- * Parameter types
-    , ArgsType (..)
-
-      -- * Internas
+      -- * Internals
     , Delete
     ) where
 
@@ -30,32 +29,29 @@ import Data.Text (Text)
 import Prolens (Lens)
 
 import GitHub.GraphQL (State)
+import GitHub.RequiredField (RequiredField (..))
 
-
-{- | Type of fields for arguments.
--}
-data ArgsType
-    = ArgsOwner
-    | ArgsName
-    | ArgsLimit
-    | ArgsStates
-
-{- | Typeclass for lenses that can change owner and name
--}
-class HasOwnerName (r :: [ArgsType] -> Type) where
-    ownerL :: Lens (r args) (r (Delete 'ArgsOwner args)) Text Text
-    nameL  :: Lens (r args) (r (Delete 'ArgsName args)) Text Text
 
 {- | Typeclass for lenses that can change the limit of elements.
 -}
-class HasLimit (r :: [ArgsType] -> Type) where
-    lastL  :: Lens (r args) (r (Delete 'ArgsLimit args)) Int Int
+class LimitL (r :: [RequiredField] -> Type) where
+    lastL  :: Lens (r args) (r (Delete 'FieldLimit args)) Int Int
     -- firstL :: Lens (r args) (r (Delete 'ArgsLimit args)) Int Int
+
+{- | Typeclass for lenses that can change owner.
+-}
+class OwnerL (r :: [RequiredField] -> Type) where
+    ownerL :: Lens (r args) (r (Delete 'FieldOwner args)) Text Text
+
+{- | Typeclass for lenses that can change name.
+-}
+class NameL (r :: [RequiredField] -> Type) where
+    nameL  :: Lens (r args) (r (Delete 'FieldName args)) Text Text
 
 {- | Typeclass for lenses that can change states.
 -}
-class HasStates (r :: [ArgsType] -> Type) where
-    statesL :: Lens (r args) (r (Delete 'ArgsStates args)) (NonEmpty State) (NonEmpty State)
+class StatesL (r :: [RequiredField] -> Type) where
+    statesL :: Lens (r args) (r (Delete 'FieldStates args)) (NonEmpty State) (NonEmpty State)
 
 
 -- Internal helpers

--- a/src/GitHub/PullRequests.hs
+++ b/src/GitHub/PullRequests.hs
@@ -27,7 +27,8 @@ import {-# SOURCE #-} GitHub.Author (AuthorField, authorToAst)
 import GitHub.Connection (Connection (..), connectionToAst)
 import GitHub.GraphQL (NodeName (..), ParamName (..), ParamValue (..), QueryNode (..),
                        QueryParam (..), State (..), mkQuery, nameNode)
-import GitHub.Lens (ArgsType (..), HasLimit (..), HasStates (..))
+import GitHub.Lens (LimitL (..), StatesL (..))
+import GitHub.RequiredField (RequiredField (..))
 
 
 {- | The @pullRequests@ connection of the 'Repository' object.
@@ -48,23 +49,23 @@ pullRequestsToAst PullRequests{..} = QueryNode
 
 {- | Arguments for the 'PullRequest' connection.
 -}
-data PullRequestsArgs (args :: [ArgsType]) = PullRequestsArgs
+data PullRequestsArgs (fields :: [RequiredField]) = PullRequestsArgs
     { pullRequestsArgsLast   :: !Int
     , pullRequestsArgsStates :: !(NonEmpty State)
     }
 
-instance HasLimit PullRequestsArgs where
+instance LimitL PullRequestsArgs where
     lastL = lens pullRequestsArgsLast (\args new -> args { pullRequestsArgsLast = new })
     {-# INLINE lastL #-}
 
-instance HasStates PullRequestsArgs where
+instance StatesL PullRequestsArgs where
     statesL = lens pullRequestsArgsStates (\args new -> args { pullRequestsArgsStates = new })
     {-# INLINE statesL #-}
 
 {- | Default value of 'PullRequestsArgs'. Use methods of 'HasLimit' and
 'HasStates' to change its fields.
 -}
-defPullRequestsArgs :: PullRequestsArgs '[ 'ArgsLimit, 'ArgsStates ]
+defPullRequestsArgs :: PullRequestsArgs '[ 'FieldLimit, 'FieldStates ]
 defPullRequestsArgs = PullRequestsArgs
     { pullRequestsArgsLast = -1
     , pullRequestsArgsStates = Open :| []

--- a/src/GitHub/Repository.hs
+++ b/src/GitHub/Repository.hs
@@ -1,3 +1,9 @@
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE GADTs                #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE UndecidableInstances #-}
+
 {- |
 Copyright: (c) 2021 Kowainik
 SPDX-License-Identifier: MPL-2.0
@@ -10,6 +16,7 @@ module GitHub.Repository
     ( -- * Data types
       Repository (..)
     , RepositoryArgs (..)
+    , defRepositoryArgs
 
       -- * Smart constructors
     , repository
@@ -20,13 +27,18 @@ module GitHub.Repository
     , repositoryToAst
     ) where
 
+import Data.Kind (Constraint)
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Text (Text)
+import GHC.TypeLits (ErrorMessage (..), Symbol)
+import Prolens (lens)
+import Type.Errors.Pretty (TypeError, type (%), type (<>))
 
 import GitHub.Connection (Connection (..))
 import GitHub.GraphQL (NodeName (..), ParamName (..), ParamValue (..), Query (..), QueryNode (..),
                        QueryParam (..), mkQuery)
 import GitHub.Issues (IssueField, Issues (..), IssuesArgs, issuesToAst)
+import GitHub.Lens (ArgsType (..), HasOwnerName (..))
 import GitHub.PullRequests (PullRequestField, PullRequests (..), PullRequestsArgs,
                             pullRequestsToAst)
 
@@ -35,10 +47,14 @@ import GitHub.PullRequests (PullRequestField, PullRequests (..), PullRequestsArg
 
 * https://developer.github.com/v4/query/#connections
 -}
-data Repository = Repository
-    { repositoryArgs   :: !RepositoryArgs
-    , repositoryFields :: !(NonEmpty RepositoryField)
-    }
+data Repository where
+    Repository
+        :: forall args
+        .  HasNoRepositoryArgs args
+        => { repositoryArgs   :: !(RepositoryArgs args)
+           , repositoryFields :: !(NonEmpty RepositoryField)
+           }
+        -> Repository
 
 repositoryToAst :: Repository -> Query
 repositoryToAst Repository{..} = Query
@@ -51,12 +67,27 @@ repositoryToAst Repository{..} = Query
 
 {- | Arguments for the 'Repository' connection.
 -}
-data RepositoryArgs = RepositoryArgs
+data RepositoryArgs (args :: [ArgsType]) = RepositoryArgs
     { repositoryArgsOwner :: !Text
     , repositoryArgsName  :: !Text
     }
 
-repositoryArgsToAst :: RepositoryArgs -> [QueryParam]
+instance HasOwnerName RepositoryArgs where
+    ownerL = lens repositoryArgsOwner (\args new -> args { repositoryArgsOwner = new })
+    {-# INLINE ownerL #-}
+    nameL = lens repositoryArgsName (\args new -> args { repositoryArgsName = new })
+    {-# INLINE nameL #-}
+
+{- | Default value of 'RepositoryArgs'. Use methods of 'HasOwnerName'
+to change its fields.
+-}
+defRepositoryArgs :: RepositoryArgs [ 'ArgsOwner, 'ArgsName ]
+defRepositoryArgs = RepositoryArgs
+    { repositoryArgsOwner = ""
+    , repositoryArgsName  = ""
+    }
+
+repositoryArgsToAst :: RepositoryArgs args -> [QueryParam]
 repositoryArgsToAst RepositoryArgs{..} =
     [ QueryParam
         { queryParamName = ParamOwner
@@ -83,19 +114,42 @@ repositoryFieldToAst = \case
 
 {- | Smart constructor for the 'Repository' type.
 -}
-repository :: RepositoryArgs -> NonEmpty RepositoryField -> Repository
+repository
+    :: HasNoRepositoryArgs args
+    => RepositoryArgs args
+    -> NonEmpty RepositoryField
+    -> Repository
 repository repositoryArgs repositoryFields = Repository{..}
 
 {- | Smart constructor for the 'Issue' field of the 'RepositoryField'.
 -}
-issues :: IssuesArgs -> NonEmpty (Connection IssueField) -> RepositoryField
+issues :: IssuesArgs '[] -> NonEmpty (Connection IssueField) -> RepositoryField
 issues issuesArgs issuesConnections = RepositoryIssues Issues{..}
 
 {- | Smart constructor for the 'PullRequest' field of the 'RepositoryField'.
 -}
 pullRequests
-    :: PullRequestsArgs
+    :: PullRequestsArgs '[]
     -> NonEmpty (Connection PullRequestField)
     -> RepositoryField
 pullRequests pullRequestsArgs pullRequestsConnections =
     RepositoryPullRequests PullRequests{..}
+
+type family HasNoRepositoryArgs (args :: [ArgsType]) :: Constraint where
+    HasNoRepositoryArgs '[]  = (() :: Constraint)
+    HasNoRepositoryArgs args = TypeError
+        ( "You haven't set the following required fields of 'RepositoryArgs':"
+        % ""
+        % PrintArgs args
+        % "Use corresponding lenses to set values of the fields"
+        )
+
+type family PrintArgs (args :: [ArgsType]) :: ErrorMessage where
+    PrintArgs '[] = 'Text ""
+    PrintArgs (x ': xs) = ("    * " <> ShowArg x) % PrintArgs xs
+
+type family ShowArg (arg :: ArgsType) :: Symbol where
+    ShowArg 'ArgsOwner  = "owner"
+    ShowArg 'ArgsName   = "name"
+    ShowArg 'ArgsLimit  = "last or first"
+    ShowArg 'ArgsStates = "states"

--- a/src/GitHub/RequiredField.hs
+++ b/src/GitHub/RequiredField.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{- |
+Copyright: (c) 2021 Kowainik
+SPDX-License-Identifier: MPL-2.0
+Maintainer: Kowainik <xrom.xkov@gmail.com>
+
+This module provides the data type for required fields of GraphQL
+queries. Some functions and subqueries require certain field. We track
+these requirements in the type-level lists to tailor error messages
+accordingly.
+
+See the "GitHub.Lens" module for the typeclasses, responsible for
+manipulating lists of fields via the @lens@-like API.
+-}
+
+module GitHub.RequiredField
+    ( RequiredField (..)
+
+      -- * Type families for error messages
+    , DisplayFields
+    , FieldNameAndLens
+    ) where
+
+import GHC.TypeLits (ErrorMessage (..))
+import Type.Errors.Pretty (type (%))
+
+
+{- | Type of all possible required fields.
+-}
+data RequiredField
+    = FieldOwner  -- ^ owner
+    | FieldName  -- ^ name
+    | FieldLimit  -- ^ first or last
+    | FieldStates  -- ^ states
+
+{- Display all requires fields with their lens hints.
+-}
+type family DisplayFields (fields :: [RequiredField]) :: ErrorMessage where
+    DisplayFields '[] = 'Text ""
+    DisplayFields (x ': xs) = FieldNameAndLens x % DisplayFields xs
+
+{- | Type family to display a single required fields with the
+corresponding lens hint.
+-}
+type family FieldNameAndLens (field :: RequiredField) :: ErrorMessage where
+    FieldNameAndLens 'FieldOwner =
+        "    * owner"
+      % "        Lens: ownerL from GitHub.Lens.OwnerL"
+    FieldNameAndLens 'FieldName =
+        "    * name"
+      % "        Lens: nameL from GitHub.Lens.NameL"
+    FieldNameAndLens 'FieldLimit =
+        "    * last or first"
+      % "        Lens: nameL from GitHub.Lens.LimitL"
+    FieldNameAndLens 'FieldStates =
+        "    * states"
+      % "        Lens: nameL from GitHub.Lens.StatesL"


### PR DESCRIPTION
Resolves #10

It works! The errors messages are on the screenshot below:
![Screenshot from 2021-01-05 16-48-31](https://user-images.githubusercontent.com/4276606/103673754-dd72fa80-4f75-11eb-97ce-76073410200b.png)

Currently, I've implemented this only for the `Repository` type, but it's the same pattern for the `IssuesArgs` and `PullRequestsArgs`. It looks a bit complicated, so, @vrom911, please review and let me know if we should proceed with this 🙂 

I think, the quality of our custom error messages can be really great! So, in the same spirit, any suggestions to improving error messages are appreciated. For example, one alternative more verbose error message:

```haskell
You haven't set some of the required fields of 'RepositoryArgs'.
Typically, you set values of this type using lenses:

    defRepositoryArgs
    & set ownerL "owner-name"
    & set nameL "repository-name"

Use corresponding lenses to set the following missing fields:
      
    * name
        Lens: nameL (from GitHub.Lens.HasOwnerName)
```

I recommend to start review from the `GitHub.Lens` module, then `GitHub.Issues` and `GitHub.PullRequests`, and then `GitHub.Repository`.