### PR TITLE
[#25] Minimal requirements to support `hit-on`

### DIFF
--- a/github-graphql.cabal
+++ b/github-graphql.cabal
@@ -68,7 +68,7 @@ library
                          GitHub.Connection
                          GitHub.GraphQL
                          GitHub.Id
-                         GitHub.Issues
+                         GitHub.Issue
                          GitHub.Label
                          GitHub.Lens
                          GitHub.Milestone

--- a/src/GitHub.hs
+++ b/src/GitHub.hs
@@ -15,7 +15,7 @@ module GitHub
 
       -- * Queries connections
       -- ** Issues
-    , module GitHub.Issues
+    , module GitHub.Issue
     , module GitHub.Order
 
       -- ** PullRequests
@@ -53,7 +53,7 @@ import GitHub.Author
 import GitHub.Connection
 import GitHub.GraphQL
 import GitHub.Id
-import GitHub.Issues
+import GitHub.Issue
 import GitHub.Label
 import GitHub.Lens
 import GitHub.Milestone

--- a/src/GitHub/Author.hs
+++ b/src/GitHub/Author.hs
@@ -21,7 +21,7 @@ module GitHub.Author
 import Data.List.NonEmpty (NonEmpty (..))
 
 import GitHub.GraphQL (NodeName (..), QueryNode (..), mkQuery, nameNode)
-import GitHub.Issues (IssueField (..))
+import GitHub.Issue (IssueField (..))
 import GitHub.PullRequests (PullRequestField (..))
 
 

--- a/src/GitHub/GraphQL.hs
+++ b/src/GitHub/GraphQL.hs
@@ -52,6 +52,7 @@ import qualified Data.Text as Text
 newtype Query = Query
     { unQuery :: [QueryNode]
     } deriving stock (Show)
+      deriving newtype (Semigroup, Monoid)
 
 {- | Smart constructor for creating 'Query' from any 'Foldable'
 container (e.g. list of fields, 'NonEmpty' of smth, etc.)
@@ -86,9 +87,11 @@ nameNode name = QueryNode
     }
 
 data NodeName
-    = NodeAssignees
+    = NodeAddAssigneesToAssignable
+    | NodeAssignees
     | NodeAuthor
     | NodeBody
+    | NodeClientMutationId
     | NodeCreateIssue
     | NodeEdges
     | NodeId
@@ -118,17 +121,21 @@ data QueryParam = QueryParam
     } deriving stock (Show)
 
 data ParamName
-    = ParamOwner
-    | ParamName
-    | ParamTitle
-    | ParamLast
-    | ParamStates
-    | ParamOrderBy
-    | ParamField
+    = ParamAssignableId
+    | ParamAssigneeIds
     | ParamDirection
+    | ParamField
+    | ParamHeadRefName
     | ParamInput
-    | ParamRepositoryId
+    | ParamLast
     | ParamMilestoneId
+    | ParamName
+    | ParamNumber
+    | ParamOrderBy
+    | ParamOwner
+    | ParamRepositoryId
+    | ParamStates
+    | ParamTitle
     deriving stock (Show)
 
 data ParamValue
@@ -187,6 +194,15 @@ data ParamValue
     @
     -}
     | ParamRecordV (NonEmpty QueryParam)
+
+    {- | List parameters:
+
+    @
+    assignees: ["foo", "bar"]
+    @
+    -}
+    -- TODO: use GADT to allow only single type
+    | ParamArrayV [ParamValue]
     deriving stock (Show)
 
 ----------------------------------------------------------------------------

--- a/src/GitHub/Id.hs
+++ b/src/GitHub/Id.hs
@@ -15,8 +15,10 @@ module GitHub.Id
     ( -- * Main ID type
       Id (..)
     , IdType (..)
+    , castId
 
       -- * Different IDs
+    , AnyId
     , MilestoneId
     , RepositoryId
     ) where
@@ -37,8 +39,16 @@ instance FromJSON (Id idType) where
     parseJSON = withObject "Id" $ \o -> Id <$> (o .: "id")
 
 data IdType
-    = IDRepository
+    = IDAny
+    | IDRepository
     | IDMilestone
 
+type AnyId = Id 'IDAny
 type RepositoryId = Id 'IDRepository
 type MilestoneId = Id 'IDMilestone
+
+castId
+    :: forall (to :: IdType) (from :: IdType)
+    .  Id from
+    -> Id to
+castId (Id i) = Id i

--- a/src/GitHub/Lens.hs
+++ b/src/GitHub/Lens.hs
@@ -20,6 +20,7 @@ module GitHub.Lens
     , FieldL (..)
     , LimitL (..)
     , NameL (..)
+    , NumberL (..)
     , OrderL (..)
     , OwnerL (..)
     , RepositoryIdL (..)
@@ -86,6 +87,11 @@ class RepositoryIdL (r :: [RequiredField] -> Type) where
 -}
 class OrderL (r :: [RequiredField] -> Type) where
     orderL :: Lens' (r args) (Maybe (Order '[]))
+
+{- | Typeclass for lenses that can change number.
+-}
+class NumberL (r :: [RequiredField] -> Type) where
+    numberL :: Lens (r args) (r (Delete 'FieldNumber args)) Int Int
 
 -- Internal helpers
 

--- a/src/GitHub/Milestone.hs
+++ b/src/GitHub/Milestone.hs
@@ -27,7 +27,7 @@ import Prolens (lens)
 import GitHub.Connection (Connection (..), connectionToAst)
 import GitHub.GraphQL (NodeName (..), ParamName (..), ParamValue (..), QueryNode (..),
                        QueryParam (..), mkQuery, nameNode)
-import GitHub.Issues (Issues, issuesToAst)
+import GitHub.Issue (Issues, issuesToAst)
 import GitHub.Lens (LimitL (..), OrderL (..))
 import GitHub.Order (Order, maybeOrderToAst)
 import GitHub.RequiredField (RequiredField (..))

--- a/src/GitHub/Query.hs
+++ b/src/GitHub/Query.hs
@@ -43,10 +43,12 @@ import GitHub.Render (renderTopMutation, renderTopQuery)
 
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
+import qualified Data.Text.IO as TextIO
 
 import qualified GitHub.Lens as GH
 import qualified GitHub.Repository as GH
 
+import qualified Data.ByteString.Lazy as LBS
 
 {- | GitHub OAuth token.
 -}
@@ -145,6 +147,9 @@ callGitHubRaw
 callGitHubRaw (GitHubToken token) text = do
     manager <- newTlsManager
 
+    TextIO.putStrLn ">>> Query"
+    TextIO.putStrLn text
+
     initialRequest <- parseRequest "https://api.github.com/graphql"
     let queryBody = object ["query" .= text]
 
@@ -159,6 +164,9 @@ callGitHubRaw (GitHubToken token) text = do
 
     -- calling the API
     response <- httpLbs request manager
+
+    TextIO.putStrLn ">>> Response"
+    LBS.putStrLn $ responseBody response
 
     case statusCode $ responseStatus response of
         200 -> case eitherDecode @(GitHubDataResponse a) (responseBody response) of

--- a/src/GitHub/Query.hs
+++ b/src/GitHub/Query.hs
@@ -43,12 +43,10 @@ import GitHub.Render (renderTopMutation, renderTopQuery)
 
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
-import qualified Data.Text.IO as TextIO
 
 import qualified GitHub.Lens as GH
 import qualified GitHub.Repository as GH
 
-import qualified Data.ByteString.Lazy as LBS
 
 {- | GitHub OAuth token.
 -}
@@ -147,9 +145,6 @@ callGitHubRaw
 callGitHubRaw (GitHubToken token) text = do
     manager <- newTlsManager
 
-    TextIO.putStrLn ">>> Query"
-    TextIO.putStrLn text
-
     initialRequest <- parseRequest "https://api.github.com/graphql"
     let queryBody = object ["query" .= text]
 
@@ -164,9 +159,6 @@ callGitHubRaw (GitHubToken token) text = do
 
     -- calling the API
     response <- httpLbs request manager
-
-    TextIO.putStrLn ">>> Response"
-    LBS.putStrLn $ responseBody response
 
     case statusCode $ responseStatus response of
         200 -> case eitherDecode @(GitHubDataResponse a) (responseBody response) of

--- a/src/GitHub/Render.hs
+++ b/src/GitHub/Render.hs
@@ -47,30 +47,32 @@ renderQueryNode i QueryNode{..} =
 
 renderNodeName :: NodeName -> Text
 renderNodeName = \case
-    NodeAssignees          -> "assignees"
-    NodeAuthor             -> "author"
-    NodeBody               -> "body"
-    NodeCreateIssue        -> "createIssue"
-    NodeEdges              -> "edges"
-    NodeId                 -> "id"
-    NodeIssue              -> "issue"
-    NodeIssues             -> "issues"
-    NodeLabels             -> "labels"
-    NodeLogin              -> "login"
-    NodeMilestone          -> "milestone"
-    NodeMilestones         -> "milestones"
-    NodeName               -> "name"
-    NodeNodes              -> "nodes"
-    NodeNumber             -> "number"
-    NodeProgressPercentage -> "progressPercentage"
-    NodePullRequests       -> "pullRequests"
-    NodeRepository         -> "repository"
-    NodeResourcePath       -> "resourcePath"
-    NodeState              -> "state"
-    NodeTitle              -> "title"
-    NodeTotalCount         -> "totalCount"
-    NodeUrl                -> "url"
-    NodeViewer             -> "viewer"
+    NodeAddAssigneesToAssignable -> "addAssigneesToAssignable"
+    NodeAssignees                -> "assignees"
+    NodeAuthor                   -> "author"
+    NodeBody                     -> "body"
+    NodeClientMutationId         -> "clientMutationId"
+    NodeCreateIssue              -> "createIssue"
+    NodeEdges                    -> "edges"
+    NodeId                       -> "id"
+    NodeIssue                    -> "issue"
+    NodeIssues                   -> "issues"
+    NodeLabels                   -> "labels"
+    NodeLogin                    -> "login"
+    NodeMilestone                -> "milestone"
+    NodeMilestones               -> "milestones"
+    NodeName                     -> "name"
+    NodeNodes                    -> "nodes"
+    NodeNumber                   -> "number"
+    NodeProgressPercentage       -> "progressPercentage"
+    NodePullRequests             -> "pullRequests"
+    NodeRepository               -> "repository"
+    NodeResourcePath             -> "resourcePath"
+    NodeState                    -> "state"
+    NodeTitle                    -> "title"
+    NodeTotalCount               -> "totalCount"
+    NodeUrl                      -> "url"
+    NodeViewer                   -> "viewer"
 
 renderQueryParam :: QueryParam -> Text
 renderQueryParam QueryParam{..} =
@@ -80,17 +82,21 @@ renderQueryParam QueryParam{..} =
 
 renderParamName :: ParamName -> Text
 renderParamName = \case
-    ParamOwner        -> "owner"
-    ParamName         -> "name"
-    ParamTitle        -> "title"
-    ParamLast         -> "last"
-    ParamStates       -> "states"
-    ParamOrderBy      -> "orderBy"
-    ParamField        -> "field"
+    ParamAssignableId -> "assignableId"
+    ParamAssigneeIds  -> "assigneeIds"
     ParamDirection    -> "direction"
+    ParamField        -> "field"
+    ParamHeadRefName  -> "headRefName"
     ParamInput        -> "input"
-    ParamRepositoryId -> "repositoryId"
+    ParamLast         -> "last"
     ParamMilestoneId  -> "milestoneId"
+    ParamName         -> "name"
+    ParamNumber       -> "number"
+    ParamOrderBy      -> "orderBy"
+    ParamOwner        -> "owner"
+    ParamRepositoryId -> "repositoryId"
+    ParamStates       -> "states"
+    ParamTitle        -> "title"
 
 renderParamValue :: ParamValue -> Text
 renderParamValue = \case
@@ -102,6 +108,7 @@ renderParamValue = \case
     ParamOrderDirection d -> renderOrderDirection d
     ParamRecordV (p :| ps) -> between "{" "}"
         $ T.intercalate ", " $ map renderQueryParam (p:ps)
+    ParamArrayV array -> renderList renderParamValue array
   where
     renderList :: (a -> Text) -> [a] -> Text
     renderList render = between "[" "]" . T.intercalate ", " . map render

--- a/src/GitHub/Repository.hs
+++ b/src/GitHub/Repository.hs
@@ -21,6 +21,7 @@ module GitHub.Repository
 
       -- * Smart constructors
     , repository
+    , issue
     , issues
     , pullRequests
     , milestones
@@ -38,7 +39,8 @@ import Type.Errors.Pretty (TypeError, type (%))
 import GitHub.Connection (Connection (..))
 import GitHub.GraphQL (NodeName (..), ParamName (..), ParamValue (..), Query (..), QueryNode (..),
                        QueryParam (..), mkQuery, nameNode)
-import GitHub.Issues (IssueField, Issues (..), IssuesArgs, issuesToAst)
+import GitHub.Issue (Issue (..), IssueArgs (..), IssueField, Issues (..), IssuesArgs, issueToAst,
+                     issuesToAst)
 import GitHub.Lens (NameL (..), OwnerL (..))
 import GitHub.Milestone (MilestoneField, Milestones (..), MilestonesArgs (..), milestonesToAst)
 import GitHub.PullRequests (PullRequestField, PullRequests (..), PullRequestsArgs,
@@ -110,6 +112,7 @@ repositoryArgsToAst RepositoryArgs{..} =
 -}
 data RepositoryField
     = RepositoryId
+    | RepositoryIssue Issue
     | RepositoryIssues Issues
     | RepositoryMilestones Milestones
     | RepositoryPullRequests PullRequests
@@ -117,6 +120,7 @@ data RepositoryField
 repositoryFieldToAst :: RepositoryField -> QueryNode
 repositoryFieldToAst = \case
     RepositoryId                             -> nameNode NodeId
+    RepositoryIssue issueField               -> issueToAst issueField
     RepositoryIssues issuesField             -> issuesToAst issuesField
     RepositoryMilestones milestonesField     -> milestonesToAst milestonesField
     RepositoryPullRequests pullRequestsField -> pullRequestsToAst pullRequestsField
@@ -129,6 +133,12 @@ repository
     -> NonEmpty RepositoryField
     -> Repository
 repository repositoryArgs repositoryFields = Repository{..}
+
+{- | Smart constructor for the 'RepositoryIssues' field of the
+'RepositoryField'.
+-}
+issue :: IssueArgs '[] -> NonEmpty (Connection IssueField) -> RepositoryField
+issue issueArgs issueConnections = RepositoryIssue Issue{..}
 
 {- | Smart constructor for the 'RepositoryIssues' field of the
 'RepositoryField'.

--- a/src/GitHub/RequiredField.hs
+++ b/src/GitHub/RequiredField.hs
@@ -40,6 +40,7 @@ data RequiredField
     | FieldDirection  -- ^ direction
     | FieldField  -- ^ field
     | FieldRepositoryId  -- ^ repositoryId
+    | FieldNumber  -- ^ number
 
 {- Display all requires fields with their lens hints.
 -}
@@ -75,3 +76,6 @@ type family FieldNameAndLens (field :: RequiredField) :: ErrorMessage where
     FieldNameAndLens 'FieldRepositoryId =
         "    * repositoryId"
       % "        Lens: repositoryIdL from GitHub.Lens.RepositoryIdL"
+    FieldNameAndLens 'FieldNumber =
+        "    * number"
+      % "        Lens: numberL from GitHub.Lens.NumberL"

--- a/src/GitHub/Title.hs
+++ b/src/GitHub/Title.hs
@@ -10,7 +10,7 @@ module GitHub.Title
     ( HasTitle (..)
     ) where
 
-import GitHub.Issues (IssueField (..))
+import GitHub.Issue (IssueField (..))
 import GitHub.PullRequests (PullRequestField (..))
 
 

--- a/test/Test/Render.hs
+++ b/test/Test/Render.hs
@@ -45,6 +45,7 @@ exampleQuery = GH.repository
         ( GH.defPullRequestsArgs
         & set GH.lastL 3
         & set GH.statesL (GH.one GH.merged)
+        & set GH.headRefNameL (Just "patch-1")
         )
         (GH.one $ GH.nodes $
            GH.title :|
@@ -65,7 +66,7 @@ queryRendered = T.unlines
     , "        }"
     , "      }"
     , "    }"
-    , "    pullRequests(last: 3, states: [MERGED]) {"
+    , "    pullRequests(last: 3, states: [MERGED], headRefName: \"patch-1\") {"
     , "      nodes {"
     , "        title"
     , "        author {"


### PR DESCRIPTION
Resolves #25

This is finally resolved!

Unfortunately, GraphQL doesn't have an API for forking, so we will need to use `hub` for that. But `hub` can easily fork. It is just:

```shell
hub clone foo/bar
hub fork
```